### PR TITLE
dtntrigger: Add support for multiple arg command lines

### DIFF
--- a/src/bin/dtntrigger.rs
+++ b/src/bin/dtntrigger.rs
@@ -38,7 +38,11 @@ impl Connection {
             .arg(bndl.primary.source.to_string())
             .arg(fname_param)
             .output() 
-            {
+          .unwrap_or_else(
+                |e| {
+                    eprintln!("Error executing command: {}", e);
+                    std::process::exit(1);
+                }); 
                 Ok(out) => out,
                 Err(e) => {
                     eprintln!("Error executing command: {}", e);

--- a/src/bin/dtntrigger.rs
+++ b/src/bin/dtntrigger.rs
@@ -30,7 +30,7 @@ impl Connection {
     fn execute_cmd(&self, data_file: NamedTempFile, bndl: &Bundle) -> Result<()> {
         let fname_param = format!("{}", data_file.path().display());
         let cmd_args = &mut self.command.split_whitespace();
-        let mut command = Command::new(cmd_args.next().unwrap());
+        let mut command = Command::new(cmd_args.next().unwrap());  //empty string handled by clap
         while let Some(arg) = cmd_args.next() {
             command.arg(arg);
         }
@@ -45,7 +45,7 @@ impl Connection {
                     process::exit(1);
                 },
             };
-
+            
         if !output.status.success() || self.verbose {
             println!("status: {}", output.status);
             std::io::stdout().write_all(&output.stdout)?;
@@ -125,7 +125,8 @@ fn main() -> anyhow::Result<()> {
                 .value_name("CMD")
                 .help("Command to execute for incoming bundles, param1 = source, param2 = payload file")
                 .required(true)
-                .takes_value(true),
+                .takes_value(true)
+                .empty_values(false),
         )
         .arg(
             Arg::with_name("verbose")

--- a/src/bin/dtntrigger.rs
+++ b/src/bin/dtntrigger.rs
@@ -29,7 +29,7 @@ impl Connection {
     }
     fn execute_cmd(&self, data_file: NamedTempFile, bndl: &Bundle) -> Result<()> {
         let fname_param = format!("{}", data_file.path().display());
-        let cmd_args = &mut self.command.split(" ");
+        let cmd_args = &mut self.command.split_whitespace();
         let mut command = Command::new(cmd_args.next().unwrap());
         while let Some(arg) = cmd_args.next() {
             command.arg(arg);

--- a/src/bin/dtntrigger.rs
+++ b/src/bin/dtntrigger.rs
@@ -34,22 +34,16 @@ impl Connection {
         while let Some(arg) = cmd_args.next() {
             command.arg(arg);
         }
-        let output = match command
+        let output = command
             .arg(bndl.primary.source.to_string())
             .arg(fname_param)
             .output() 
-          .unwrap_or_else(
+            .unwrap_or_else(
                 |e| {
                     eprintln!("Error executing command: {}", e);
                     std::process::exit(1);
-                }); 
-                Ok(out) => out,
-                Err(e) => {
-                    eprintln!("Error executing command: {}", e);
-                    process::exit(1);
-                },
-            };
-            
+            }); 
+
         if !output.status.success() || self.verbose {
             println!("status: {}", output.status);
             std::io::stdout().write_all(&output.stdout)?;


### PR DESCRIPTION
Got another small tweak for you.

I wanted to be able to execute shell scripts, and since the scripts themselves aren't executable binaries, you need to call the shell interpreter first.

Modified dtntrigger to allow commands such as:

./dtntrigger --command "/bin/bash ./test.sh test_arg" -e dtn://example/