### PR TITLE
fix: missing emission of Registered packet in ECLA websocket client.

### DIFF
--- a/core/dtn7/src/cla/ecla/ws_client.rs
+++ b/core/dtn7/src/cla/ecla/ws_client.rs
@@ -142,6 +142,11 @@ impl Client {
                                 error!("Error while sending ForwardData to channel: {}", err);
                             }
                         }
+                        Packet::Registered(reg) => {
+                            if let Err(err) = self.packet_out.send(Packet::Registered(reg)).await {
+                                error!("Error while sending Registered to channel: {}", err);
+                            }
+                        }
                         Packet::Beacon(mut pdp) => {
                             pdp.addr = self.id.clone();
 


### PR DESCRIPTION
I noticed that I forgot the emission of the ``Registered`` packet in the ECLA websocket client, which is important if you want to get the node id in the ECLA.