### PR TITLE
documentation: various improvements

### DIFF
--- a/doc/ecla-getting-started.md
+++ b/doc/ecla-getting-started.md
@@ -16,10 +16,12 @@ debug = false
 beacon-period = true
 generate-status-reports = false
 parallel-bundle-processing = false
-routing = "epidemic"
 webport = 3000
 workdir = "/tmp/dtn7"
 db = "mem"
+
+[routing]
+strategy = "epidemic"
 
 [core]
 janitor = "10s"

--- a/doc/ecla-getting-started.md
+++ b/doc/ecla-getting-started.md
@@ -6,7 +6,9 @@ First, you need to enable the ECLA in dtnd. It's done by adding the ``--ecla`` f
 dtnd -w 3000 -r epidemic -n node1 --ecla
 ```
 
-By default if ECLA is enabled the WebSocket transport layer is running under the web port of dtnd as specified by ``-w``, ``--web-port``. In the example above the port would be 3000 (``-w 3000``).
+By default, if ECLA is enabled, the WebSocket transport layer is running under the web port of dtnd as specified by ``-w``, ``--web-port``.
+In the example above the port would be 3000 (``-w 3000``).
+(If the TCP transport layer for connecting ECLAs is desired, it can be activated via setting the ``--ecla-tcp XYZ`` flag.)
 
 ## Example Config File
 
@@ -42,7 +44,7 @@ tcp_port = 0
 
 The registration process fails with a ``already registered`` error packet as a response and the connection will be closed by dtnd.
 
-### Where does my WebSocket client needs to connect to?
+### Where does my WebSocket client need to connect to?
 
 The WebSocket is accessible under the same port as defined by ``-w``, ``--web-port`` and the route ``/ws/ecla``. An example for a web port 3000 would be ``127.0.0.1:3000/ws/ecla``.
 

--- a/doc/ecla.md
+++ b/doc/ecla.md
@@ -20,7 +20,8 @@ The WebSocket is accessible under the same port as defined by ``-w``, ``--web-po
 
 ### TCP
 
-If the TCP Transport Layer is used the packets use a big-endian length delimited codec. More information about the codec can be found here: [tokio_util::codec::length_delimited](https://docs.rs/tokio-util/0.2.0/tokio_util/codec/length_delimited/index.html). This layer will be activated if the tcp port is set via the ``-ecla-tcp 7263`` flag.
+If the TCP Transport Layer is used, the packets use a big-endian length delimited codec. More information about the codec can be found here: [tokio_util::codec::length_delimited](https://docs.rs/tokio-util/0.2.0/tokio_util/codec/length_delimited/index.html).
+This layer will be activated if the tcp port is set via the ``--ecla-tcp 7263`` flag.
 
 ```
 +----------+--------------------------------+
@@ -49,9 +50,14 @@ Normally dntd won't accept static peers for CLAs that are not present at startup
 
 ### Registration
 
-After the initial connect to the ECLA the first packet that must be send is the ``RegisterPacket`` that contains the name of the CLA and if the beacon system should be enabled. If the registration is successful the ECLA responds with a ``RegisteredPacket`` containing basic information about the connected dtnd node. If a error occured a ``ErrorPacket`` will be returned. Reasons for error can be:
+After the initial connect to the ECLA, the first packet that must be sent is the ``Register`` packet that contains the name of the CLA and if the beacon system should be enabled.
+Important detail: The name of the ECLA needs to be the same at all dtn7 instances in order to function.
+If the registration is successful, the ECLA responds with a ``Registered`` packet containing basic information about the connected dtnd node.
+If an error occurred, an ``Error`` packet will be returned.
+Reasons for errors can be:
 - CLA with the same name is already registered
 - Illegal name (e.g. empty)
+- Name too long (maximum is 64 characters)
 
 #### Example Sequence
 
@@ -63,11 +69,13 @@ After the initial connect to the ECLA the first packet that must be send is the 
 
 #### Coming from dtnd
 
-If you receive the packet from the dtnd that means the ECL-Module should send the packet to the address specified in ``dst`` field. If no ``dst`` is specified, for example when the transmission layer doesn't have addressable id's send the packet to all possible targets. In case the transmission layer has addressable id's you must set the ``src`` field to the address of the ECL-Module.
+If you receive a packet from dtnd, that means the ECL-Module should send the packet to the address specified in the ``dst`` field.
+If no ``dst`` is specified, for example, when the transmission layer doesn't have addressable IDs, then send the packet to all possible targets.
+In case the transmission layer has addressable IDs, you must set the ``src`` field to the address of the ECL-Module.
 
 #### Coming from the Transmission Layer
 
-If you receive a packet from the transmission layer you must pass it to the ECLA as it is.
+If you receive a packet from the transmission layer, you must pass it to dtnd's ECLA endpoint as it is.
 
 #### Example Sequence
 
@@ -75,15 +83,17 @@ If you receive a packet from the transmission layer you must pass it to the ECLA
 
 ### Beacon
 
-If the beacon is enabled dtnd will periodically send beacons to the ECL-Module acting as a basic peer discovery. The interval is specified by the ``announcement_interval`` (``-interval``, ``-i`` cli flag).
+If the beacon is enabled, dtnd will periodically send beacons to the ECL-Module, acting as a basic peer discovery.
+The interval is specified by the ``announcement_interval`` (``--interval``, ``-i`` cli flag).
 
 #### Coming from dtnd
 
-If you receive the packet from the dtnd that means the ECL-Module can send the beacon to all reachable devices. If the transmission layer has addressable id's the ECL-Module should set the ``addr`` field to it's own id.
+If you receive the packet from dtnd, that means the ECL-Module can send the beacon to all reachable devices.
+If the transmission layer has addressable IDs, the ECL-Module should set the ``addr`` field to its own id.
 
 #### Coming from the Transmission Layer
 
-If you receive a packet from the transmission layer you can pass it to the ECLA as it is.
+If you receive a packet from the transmission layer, you can pass it to dtnd's ECLA endpoint as it is.
 
 #### Example Sequence
 

--- a/doc/erouting-getting-started.md
+++ b/doc/erouting-getting-started.md
@@ -1,6 +1,7 @@
 # External Routing Getting Started
 
-First, you need to enable the external routing in dtnd. It's done by changing the routing strategy to ``external`` in the dtnd arguments. An example would be:
+First, you need to enable the external routing in `dtnd`.
+It's done by changing the routing strategy to ``external`` in the dtnd arguments. An example would be:
 
 ```
 dtnd -w 3000 -r external -n node1

--- a/doc/erouting.md
+++ b/doc/erouting.md
@@ -10,10 +10,11 @@ To enable the erouting use ``-r external`` as a routing algorithm.
 
 ## Config File
 
-Configuration can also happen via a config file by setting the routing to ``external``.
+Configuration can also happen via a config file by setting the routing strategy to ``external``.
 
 ```toml
-routing = "external"
+[routing]
+strategy = "external"
 ```
 
 ## WebSocket Transport Layer

--- a/doc/erouting.md
+++ b/doc/erouting.md
@@ -83,7 +83,7 @@ The ``Error`` is emitted when an error occurs. At the Moment the only emitted er
 
 dtnd → external
 
-The ``Timeout`` is emitted when no ``SenderForBundleReponse`` was recieved or the timeout (250ms) ran out.
+The ``Timeout`` is emitted when an expected ``ReponseSenderForBundle`` was not received until the timeout (250ms) ran out.
 
 ```json
 {
@@ -109,7 +109,7 @@ The ``IncomingBundle`` is emitted when a bundle is incoming.
 
 dtnd → external
 
-The ``IncomingBundleWithoutPreviousNode`` is emitted when a bundle is incoming with a previous node.
+The ``IncomingBundleWithoutPreviousNode`` is emitted when a bundle is incoming without a previous node.
 
 ```json
 {
@@ -235,7 +235,7 @@ In order to implement a basic routing strategy you most likely want to do the fo
   - Saving the initial ``PeerState``
   - Adding peer if ``PeerEncountered`` packet is received
   - Removing peer ``PeerDropped`` packet is received
-- Responding to ``SenderForBundle`` packet with a ``ResponseSenderForBundle`` packet based on some kind of strategy and most likely involving the available peers.
+- Responding to ``RequestSenderForBundle`` packet with a ``ResponseSenderForBundle`` packet based on some kind of strategy and most likely involving the available peers.
 
 ## Python Example: Direct Routing
 
@@ -298,7 +298,7 @@ def on_sender_for_bundle(msg):
   dest = msg["bp"]["destination"]
   bundle_id = msg["bp"]["id"]
 
-  print("===> SenderForBundle: To", dest[1], bundle_id)
+  print("===> RequestSenderForBundle: To", dest[1], bundle_id)
 
   # Check if already delivered
   global delivered

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -34,7 +34,7 @@ docker run --rm -it                             \
     -p 1190:1190                                \
     -p 6080:6080                                \
     -v /tmp/shared:/shared                      \
-    --privileged                                \
+    --cap-add=ALL                               \
     gh0st42/dtn7-showroom
 ```
 
@@ -55,13 +55,14 @@ A complete desktop with access to `core-gui` is provided through a web vnc on ht
 
 ### Configure wireless network
 
-In the `core-gui` click on the network nodes symbol left of the canvas and select the *host* as node type. Then place it three times on the canvas.
-Now select *wireless LAN* from the link node types and place it on the canvas.
-Use the link tool (the one below the run and cursor buttons on the left side) and connect all nodes to the wifi.
+In the `core-gui` click on the container nodes symbol left of the canvas and select the *host* as node type. Then place it three times on the canvas.
+Now select *wireless LAN* from the link layer node types and place it on the canvas.
+Use the link tool (3 dots with lines between them) and connect all nodes to the wifi by dragging a line.
 By double-clicking each node you have to change the IPv4 subnet mask from `/32` to `/24`.
+You also might need to change the interface from `eth0` to one you have, type `ls -1 /sys/class/net/` in the open terminal to check which adapters exist.
 
 The simulation can be then started by pressing the green start button.
-When dragging nodes in the running simulation around a green line should appear once they are in communication range.
+When dragging nodes in the running simulation around, a green line should appear iff they are in communication range.
 
 By double-clicking a node in a running session you can get a terminal on this node.
 To verify that everything works you should be able to `ping` nodes with a green line and when dragging them out of reach the packets should get lost.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -71,7 +71,7 @@ If this is not the case you might be missing the proper kernel modules on your h
 
 By using the [core helper](https://github.com/gh0st42/core-helpers) scripts managing the simulation gets much easier.
 
-To start `dtnd` on all running nodes enter the following in the ssh session connected to the docker instance:
+To start `dtnd` on all running nodes enter the following in the bash that we previously connected to the docker instance:
 ```bash
 cda 'dtnd -n $(hostname) -e incoming -C mtcp -r epidemic'
 ```
@@ -79,7 +79,7 @@ cda 'dtnd -n $(hostname) -e incoming -C mtcp -r epidemic'
 This starts `dtnd` with a node naming matching its hostname in the simulation, registers an endpoint called `incoming`, uses minimal tcp convergence layer and *epidemic* routing.
 A full list of options can be seen by executing `dtnd -h`.
 
-Each node has a directly with logs and local files under `/tmp/pycore.*/n<node number>`.
+Each node has logs and a directory with local files under `/tmp/pycore.*/n<node number>.<conf/log>`.
 
 The dtn daemon can be stopped and the standard out log can be cleared with the following command:
 ```bash
@@ -94,7 +94,7 @@ pkill -9 dtnd && cea rm nohup.out
 
 #### Get global peer list
 
-To get a list of all known peers from all nodes issue the following command in the ssh session:
+To get a list of all known peers from all nodes issue the following command in the bash session:
 ```bash
 cea 'dtnquery peers | egrep "n[0-9].:" | cut -d \" -f 2 | sort'
 ```

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -62,7 +62,7 @@ By double-clicking each node you have to change the IPv4 subnet mask from `/32` 
 You also might need to change the interface from `eth0` to one you have, type `ls -1 /sys/class/net/` in the open terminal to check which adapters exist.
 
 The simulation can be then started by pressing the green start button.
-When dragging nodes in the running simulation around, a green line should appear iff they are in communication range.
+When dragging nodes in the running simulation around, a green line should appear when they are in communication range.
 
 By double-clicking a node in a running session you can get a terminal on this node.
 To verify that everything works you should be able to `ping` nodes with a green line and when dragging them out of reach the packets should get lost.

--- a/doc/http-cl.md
+++ b/doc/http-cl.md
@@ -3,10 +3,10 @@ Simple HTTP Convergence Layer
 
 As `dtn7-rs` provides a simple HTTP API for its CLI helpers this interface can also be used to exchange bundles with other nodes.
 
-Each `dtn7-rs` node provides an `/push` endpoint that accepts RFC 9171 bundles with `POST` requests.
-Only one bundle per request is support, thus, some overhead for HTTP connection management is involved.
+Each `dtn7-rs` node provides a `/push` endpoint that accepts RFC 9171 bundles with `POST` requests.
+Only one bundle per request is supported; thus, some overhead for HTTP connection management is involved.
 
-One, can also use tools such as `curl` to push bundles into a running `dtnd` instance.
+One can also use tools such as `curl` to push bundles into a running `dtnd` instance.
 
 ```
 $ bp7 rnd -r > /tmp/bundle.cbor

--- a/examples/dtn7.toml.example
+++ b/examples/dtn7.toml.example
@@ -41,6 +41,7 @@ strategy = "epidemic"
 
 # additional parameters for the routing strategy can be set here
 settings.sprayandwait.num_copies = 7
+#settings.static.routes <routes_file>
 
 [core]
 # the janitor is responsible for cleaning the bundle buffer


### PR DESCRIPTION
- doc(ecla-getting-started): fix outdated config example
- doc(dtn7.toml.example): add example for static routes setting
- doc(getting-started): fix out-of-date instructions
- doc(erouting): fix outdated config example
- doc(erouting): fix mistakes/inaccuracies
- doc: fix wording/mistakes, add some more details