### PR TITLE
Add bundle id to params in dtntrigger

### DIFF
--- a/core/dtn7/src/bin/dtntrigger.rs
+++ b/core/dtn7/src/bin/dtntrigger.rs
@@ -34,6 +34,7 @@ fn execute_cmd(
     let output = command
         .arg(bndl.primary.source.to_string())
         .arg(fname_param)
+        .arg(bndl.id().to_string())
         .output()
         .unwrap_or_else(|e| {
             eprintln!("[!] Error executing command: {}", e);


### PR DESCRIPTION
I think it's important to pass the bundle's ID to the parameters that dtntrigger sends to the command. Specially for applications where some sort of package acknowledgement need to be deployed, it's handy to pass which bundle was received instead of having to open the bundle's payload data to identify it