### PR TITLE
Reflect flags in the ACK

### DIFF
--- a/core/dtn7/src/cla/tcp/mod.rs
+++ b/core/dtn7/src/cla/tcp/mod.rs
@@ -338,7 +338,7 @@ impl TcpSession {
                         TcpClPacket::XferAck(XferAckData {
                             tid: data.tid,
                             len: data.len,
-                            flags: XferSegmentFlags::empty(),
+                            flags: data.flags,
                         })
                         .write(&mut self.writer)
                         .await?;


### PR DESCRIPTION
One-liner fix for XferAck message.  By my reading of RFC9174, the Ack should reflect the received flags.

Section 5.2.3 says:
> The flags portion of the XFER_ACK header SHALL be set to match the corresponding XFER_SEGMENT message being acknowledged (including flags not decodable to the entity)